### PR TITLE
Push production to s3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ src/main/client/config.js
 datatools-manager.iml
 config.yml
 config_server.yml
+configurations/*
+!configurations/default

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "MIT",
   "scripts": {
     "build": "mastarm build --env production",
+    "deploy": "mastarm build --minify --env production && aws s3 cp --recursive --acl public-read dist",
     "prestart": "yarn",
     "start": "mastarm build --serve --proxy http://localhost:4000/api",
     "test": "mastarm lint \"src/main/client/**/*.js\""
@@ -23,8 +24,6 @@
     "change-case": "^3.0.0",
     "clone": "^1.0.2",
     "cors": "^2.3.1",
-    "express": "^4.13.3",
-    "express-jwt": "^3.3.0",
     "font-awesome": "^4.7.0",
     "gravatar": "^1.5.2",
     "history": "^2.0.1",
@@ -43,16 +42,17 @@
     "qs": "^6.2.1",
     "rbush": "^2.0.1",
     "rc-slider": "^5.1.1",
-    "react": "^15.2.1",
-    "react-addons-shallow-compare": "^15.1.0",
-    "react-addons-update": "^0.14.7",
+    "react": "^15.4.1",
+    "react-addons-perf": "^15.4.1",
+    "react-addons-shallow-compare": "^15.4.1",
+    "react-addons-update": "^15.4.1",
     "react-bootstrap": "^0.30.0-rc.2",
     "react-bootstrap-datetimepicker": "^0.0.22",
     "react-bootstrap-table": "^2.5.2",
     "react-color": "^2.3.4",
     "react-dnd": "^2.1.4",
     "react-dnd-html5-backend": "^2.1.2",
-    "react-dom": "^15.2.1",
+    "react-dom": "^15.4.1",
     "react-dropzone": "^3.5.3",
     "react-helmet": "^3.1.0",
     "react-leaflet": "^0.12.1",
@@ -84,7 +84,7 @@
     "validator": "^5.5.0"
   },
   "devDependencies": {
-    "mastarm": "^2.0.0"
+    "mastarm": "^3.1.0"
   },
   "standard": {
     "parser": "babel-eslint"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2744,7 +2744,7 @@ fbjs@^0.3.1:
     ua-parser-js "^0.7.9"
     whatwg-fetch "^0.9.0"
 
-fbjs@^0.8.4:
+fbjs@^0.8.1, fbjs@^0.8.4:
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.5.tgz#f69ba8a876096cb1b9bffe4d7c1e71c19d39d008"
   dependencies:
@@ -5687,13 +5687,17 @@ react-addons-perf@^15.3.2:
   version "15.3.2"
   resolved "https://registry.yarnpkg.com/react-addons-perf/-/react-addons-perf-15.3.2.tgz#bbdbebe8649f936f9636a5750ac145bf5c620213"
 
-"react-addons-shallow-compare@^0.14.0 || ^15.0.0", react-addons-shallow-compare@^15.1.0:
-  version "15.3.2"
-  resolved "https://registry.yarnpkg.com/react-addons-shallow-compare/-/react-addons-shallow-compare-15.3.2.tgz#c9edba49b9eab44d0c59024d289beb1ab97318b5"
+react-addons-perf@^15.4.1:
+  version "15.4.1"
+  resolved "https://registry.yarnpkg.com/react-addons-perf/-/react-addons-perf-15.4.1.tgz#c6dd5a7011f43cd3222f47b7cb1aebe9d4174cb0"
 
-"react-addons-update@^0.14.0 || ^15.0.0", react-addons-update@^0.14.7:
-  version "0.14.8"
-  resolved "https://registry.yarnpkg.com/react-addons-update/-/react-addons-update-0.14.8.tgz#486f1fb71e09ef8ad09c0e95fbe59d173782fe1a"
+"react-addons-shallow-compare@^0.14.0 || ^15.0.0", react-addons-shallow-compare@^15.4.1:
+  version "15.4.1"
+  resolved "https://registry.yarnpkg.com/react-addons-shallow-compare/-/react-addons-shallow-compare-15.4.1.tgz#b68103dd4d13144cb221065f6021de1822bd435a"
+
+"react-addons-update@^0.14.0 || ^15.0.0", react-addons-update@^15.4.1:
+  version "15.4.1"
+  resolved "https://registry.yarnpkg.com/react-addons-update/-/react-addons-update-15.4.1.tgz#00c07f45243aa9715e1706bbfd1f23d3d8d80bd1"
 
 react-bootstrap-datetimepicker@^0.0.22:
   version "0.0.22"
@@ -5751,9 +5755,13 @@ react-dnd@^2.1.4:
     invariant "^2.1.0"
     lodash "^4.2.0"
 
-"react-dom@^0.14.0 || ^15.0.0", "react-dom@^15.0.0 || ^16.0.0", react-dom@^15.2.1, react-dom@^15.3.2:
-  version "15.3.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.3.2.tgz#c46b0aa5380d7b838e7a59c4a7beff2ed315531f"
+"react-dom@^0.14.0 || ^15.0.0", "react-dom@^15.0.0 || ^16.0.0", react-dom@^15.3.2, react-dom@^15.4.1:
+  version "15.4.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.4.1.tgz#d54c913261aaedb17adc20410d029dcc18a1344a"
+  dependencies:
+    fbjs "^0.8.1"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.0"
 
 react-dropzone@^3.5.3:
   version "3.7.2"
@@ -5871,9 +5879,9 @@ react-virtualized@^8.0.5, react-virtualized@^8.5.0:
     classnames "^2.2.3"
     dom-helpers "^2.4.0"
 
-"react@^15.0.0 || ^16.0.0", react@^15.2.1, react@^15.3.2:
-  version "15.3.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.3.2.tgz#a7bccd2fee8af126b0317e222c28d1d54528d09e"
+"react@^15.0.0 || ^16.0.0", react@^15.3.2, react@^15.4.1:
+  version "15.4.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-15.4.1.tgz#498e918602677a3983cd0fd206dfe700389a0dd6"
   dependencies:
     fbjs "^0.8.4"
     loose-envify "^1.1.0"


### PR DESCRIPTION
This includes a temporary script for allowing you to push to S3 until I figure out why #3 is happening. If we want use CloudFront we'll have to manually invalidate for now, so let's just stick to the public s3 urls.

To deploy, run:
```sh
$ npm run deploy -- s3://datatools-prod/dist
```

This expands to `mastarm build --minify --env production && aws s3 cp --recursive --acl public-read dist "s3://datatools-prod/dist"` and builds and copies the compiled JS/CSS to the S3 bucket folder specified. Just swap out the bucket to change. 

